### PR TITLE
feat: inline topic editing, real-time comments, card nav hover

### DIFF
--- a/.opencode/agents/liveview-archtect.md
+++ b/.opencode/agents/liveview-archtect.md
@@ -105,7 +105,7 @@ Just organizing DOM elements?        → Function Component (NEVER LiveComponent
 
 ## Output Format
 
-Write to the path specified in the orchestrator's prompt (typically `.claude/plans/{slug}/research/liveview-decision.md`):
+Write to the path specified in the orchestrator's prompt (typically `.opencode/plans/{slug}/research/liveview-decision.md`):
 
 ```markdown
 # LiveView Architecture: {feature}

--- a/.opencode/plans/ui-improvements/research/liveview-decision.md
+++ b/.opencode/plans/ui-improvements/research/liveview-decision.md
@@ -1,0 +1,242 @@
+# LiveView Architecture: UI Improvements
+
+## Recommendation
+
+**Use LiveView**: Yes — but the scope is purely cosmetic/UX. No routing, data fetching, or real-time changes needed.
+
+**Rationale**: All four changes are light-touch modifications to existing templates, CSS theme config, and one layout file. Every change gets resolved at the template/CSS layer — no new LiveViews, LiveComponents, contexts, or PubSub patterns.
+
+---
+
+## Change 1 — Base Light Mode Color
+
+### Current
+
+```css
+--color-base-100: oklch(98% 0 0);       /* essentially pure white */
+--color-base-200: oklch(96% 0.001 286);
+--color-base-300: oklch(92% 0.004 286);
+```
+
+The 0 chroma in base-100 means zero saturation — pure neutral white. Combined with `--depth: 1` and `--border: 1.5px`, the page feels sterile and high-contrast with no warmth.
+
+### What I Recommend
+
+Warm the entire base stack by adding a tiny amount of chroma in the yellow-amber direction (~85° in OKLCH):
+
+```css
+/* Warm, inviting, premium */
+--color-base-100: oklch(97% 0.008 85);
+--color-base-200: oklch(94% 0.01 85);
+--color-base-300: oklch(90% 0.015 85);
+--color-base-content: oklch(21% 0.01 85);
+```
+
+**Why 85° in OKLCH?**
+- 85° maps to a warm cream/eggshell/paper tone — feels cozy, not yellow
+- Matches the "discussion" app personality (approachable, human)
+- The `primary` at 47° (amber-ish) and this new base at 85° will harmonize beautifully
+- The dark theme (252°, blue-gray) will contrast gracefully
+- Still reads as "white" — users won't think "this is beige", they'll just feel the warmth
+
+Dark theme stays untouched — it's already well-tuned at `oklch(30% 0.016 252)`.
+
+### File to Change
+
+`assets/css/app.css` — the `@plugin "../vendor/daisyui-theme" { name: "light"; ... }` block, lines 59–92.
+
+---
+
+## Change 2 — Remove "Topics" Header
+
+### Problem
+
+```heex
+<.header>   ← index.html.heex line 1–3
+  Topics
+</.header>
+```
+
+This `<.header>` is redundant — the nav bar already says "💬 Discuss", and the composer + topic list layout makes the page's purpose blindingly obvious. Twitter, Reddit, Hacker News — none of them say "Posts" at the top of their feed.
+
+### What I Recommend
+
+Delete the `<.header>` block entirely from `index.html.heex`.
+
+- The `:page_title` assign in the LiveView (`"Topics"`) remains set for the browser tab — SEO/crawlers still see `<title>Topics</title>`
+- The page flows: `composer → topic list` — cleaner, more modern
+- Remove `mt-6` from the topic list wrapper (line 53) so spacing between composer and list is tighter and feels intentional
+
+### File to Change
+
+`lib/discuss_web/live/topic_live/index.html.heex`
+
+### Screenshot Mental Model
+
+```
+Before:                    After:
+┌─────────────────────┐   ┌─────────────────────┐
+│  Topics       ← h1  │   │  [composer box]      │
+│  [composer box]     │   │  ┌─────────────────┐ │
+│  ┌──────────────┐   │   │  │ Topic Card      │ │
+│  │ Topic Card   │   │   │  │ ...             │ │
+│  │ ...          │   │   │  └─────────────────┘ │
+│  └──────────────┘   │   │  ┌─────────────────┐ │
+│  ┌──────────────┐   │   │  │ Topic Card      │ │
+│  │ Topic Card   │   │   │  │ ...             │ │
+│  │ ...          │   │   │  └─────────────────┘ │
+│  └──────────────┘   │   └─────────────────────┘
+└─────────────────────┘
+```
+
+---
+
+## Change 3 — Sign In / Sign Out Treatment
+
+### Current Problems
+
+| State | Layout | Issue |
+|-------|--------|-------|
+| Signed in | Avatar + name text "Sign Out" (3 items) | Too much horizontal real estate; name truncation is ugly |
+| Signed out | Large button "Sign in with GitHub" | Overweight for an action users do once |
+| Both | Auth widget is same visual weight as the brand | Competing focal points in the nav |
+
+### What I Recommend
+
+**Two patterns, same spot:**
+
+**Signed in:** `avatar → dropdown menu`
+- Show only the avatar (circular, 32px)
+- Click opens a small dropdown with user name + "Sign Out"
+- This is the GitHub/Linear/Vercel pattern — proven, minimalist
+
+**Signed out:** `icon + compact text`
+- GitHub icon + "Sign in" — compact button, no full sentence
+- Uses `.btn-soft` for a subtler visual weight
+
+### Implementation Approach
+
+The dropdown should be a **pure HTML `<details>` menu** — no LiveComponent, no JS needed. daisyUI has first-class support:
+
+```heex
+<details class="dropdown dropdown-end">
+  <summary class="list-none cursor-pointer">
+    <img src={@current_user.avatar_url} class="w-8 h-8 rounded-full" />
+  </summary>
+  <ul class="dropdown-content menu bg-base-100 rounded-box z-50 shadow-lg
+             mt-2 p-2 w-48 border border-base-300">
+    <li class="menu-title"><span>{@current_user.name}</span></li>
+    <li><hr class="my-1" /></li>
+    <li>
+      <.link href="/auth/signout" method="delete"
+        class="text-error hover:text-error/80">
+        Sign Out
+      </.link>
+    </li>
+  </ul>
+</details>
+```
+
+For signed-out:
+
+```heex
+<.link href="/auth/github"
+  class="btn btn-soft btn-sm gap-1.5">
+  <.icon name="hero-github" class="size-4" />
+  Sign in
+</.link>
+```
+
+### Why This Is Better
+
+| Concern | Before | After |
+|---------|--------|-------|
+| Nav visual noise | 3 elements (avatar + name + link) | 1 element (avatar) |
+| Signed-out weight | Full sentence button | Compact icon + label |
+| Horizontal space | ~250px for signed-in | ~40px for signed-in |
+| User identity | Always visible text | On-demand via dropdown |
+| Implementation complexity | None (already works) | Minimal (details + CSS) |
+
+### File to Change
+
+`lib/discuss_web/components/layouts/app.html.heex` — the auth block (lines 15–49).
+
+---
+
+## Change 4 — Bigger Topic Panels
+
+### Current vs. Proposed
+
+| Element | Current | Proposed | Why |
+|---------|---------|----------|-----|
+| Card padding | `p-5 sm:p-6` | `p-6 sm:p-8` | More breathing room, premium feel |
+| Title size | `text-base sm:text-lg` | `text-lg sm:text-xl` | Readability, visual hierarchy |
+| Title line-clamp | none | `line-clamp-2` | Prevents super-long titles breaking layout |
+| Card shadow | `shadow-sm` | `shadow-md` | Lift cards off background more |
+| Metadata bottom | inline with title | stays inline | No change needed — scales naturally |
+| Edit/Delete buttons | current | unchanged | Functional, not content |
+
+### Rationale
+
+The cards are the primary content of the page. Making them bigger:
+- Improves readability at a glance
+- Makes each topic feel more substantial
+- Creates better visual rhythm in the stream
+- The larger cards paired with a warm background (Change 1) will feel much more premium
+
+### File to Change
+
+`lib/discuss_web/live/topic_live/index.html.heex` — the topic card div (lines 60–101).
+
+---
+
+## All Files Changed (Summary)
+
+| File | Change |
+|------|--------|
+| `assets/css/app.css` | Warm the light theme base stack |
+| `lib/discuss_web/live/topic_live/index.html.heex` | Remove `<.header>`, bump card sizes, adjust spacing |
+| `lib/discuss_web/components/layouts/app.html.heex` | Replace auth widget with avatar dropdown / compact sign-in |
+
+No new modules, no new routes, no new contexts. Pure UI.
+
+---
+
+## Affordance Tables
+
+### Places
+
+| ID | Place | Entry Point | Notes |
+|----|-------|-------------|-------|
+| P1 | Topic Index LiveView | `GET /` or `GET /topics` | Main topic list |
+| P2 | Topic Show LiveView | `GET /topics/:id` | Topic detail + comments |
+| P3 | App Layout | wraps all LiveViews | Navbar with auth widget |
+
+### UI Affordances (Changes Only)
+
+| ID | Place | Component | Affordance | Type | Wires Out | Returns To |
+|----|-------|-----------|------------|------|-----------|------------|
+| U1 | P3 | Nav | Avatar | `click` → dropdown | N1 | — |
+| U2 | P3 | Nav | "Sign in" button | `click` → `/auth/github` | — | — |
+| U3 | P3 | Nav | "Sign Out" in dropdown | `click` → `/auth/signout` (DELETE) | — | — |
+
+### Code Affordances
+
+| ID | Place | Module | Affordance | Wires Out | Returns To |
+|----|-------|--------|------------|-----------|------------|
+| N1 | P3 | `app.html.heex` | `<details>` dropdown (native HTML) | none (no LV event) | — |
+
+No new code affordances needed. The dropdown uses native HTML `<details>` element — no LiveView events, no JS commands, no component mounting.
+
+---
+
+## Design Philosophy
+
+Your four requests together tell a story:
+
+1. **Warm background** → changes the emotional tone of the entire app
+2. **Remove redundant header** → trusts the user to understand what page they're on
+3. **Avatar dropdown** → reduces visual noise in the nav, puts user identity on-demand
+4. **Bigger topic cards** → makes the content feel substantial and worth reading
+
+They're all pulling in the same direction: **less noise, more warmth, bigger signal.**

--- a/.opencode/skills/docker/SKILL.md
+++ b/.opencode/skills/docker/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: docker
+description: Docker containerization best practices for building, securing, and deploying containers.
+---
+
+# Docker Development
+
+You are an expert in Docker containerization, image building, and container orchestration.
+
+## Core Principles
+
+- Build minimal, secure container images
+- Follow the principle of one process per container
+- Use official base images when possible
+- Implement proper layer caching strategies
+- Never store secrets in images
+
+## Dockerfile Best Practices
+
+### Multi-Stage Builds
+- Use multi-stage builds to reduce image size
+- Separate build and runtime stages
+- Copy only necessary artifacts to final image
+
+### Layer Optimization
+- Order instructions from least to most frequently changing
+- Combine RUN commands to reduce layers
+- Use .dockerignore to exclude unnecessary files
+- Clean up package manager caches in same layer
+
+### Base Images
+- Use specific version tags, not `latest`
+- Prefer slim or alpine variants for smaller size
+- Scan base images for vulnerabilities
+- Consider distroless images for production
+
+## Security Best Practices
+
+- Run containers as non-root user
+- Use read-only file systems where possible
+- Implement health checks
+- Scan images for vulnerabilities regularly
+- Use secrets management, not environment variables for sensitive data
+- Implement resource limits (CPU, memory)
+
+## Docker Compose
+
+### Configuration
+- Use version 3+ compose files
+- Define networks explicitly
+- Use volumes for persistent data
+- Implement depends_on with health checks
+- Use environment files for configuration
+
+### Development Workflow
+- Mount source code for hot reloading
+- Use override files for environment-specific config
+- Implement proper logging drivers
+- Use build args for build-time variables
+
+## CI/CD Integration
+
+- Build images in CI pipelines
+- Tag images with git commit SHA
+- Push to secure container registries
+- Implement automated vulnerability scanning
+- Use image signing for verification
+
+## Networking
+
+- Use user-defined bridge networks
+- Implement service discovery via DNS
+- Expose only necessary ports
+- Use network aliases for service communication
+
+## Logging and Monitoring
+
+- Use appropriate logging drivers
+- Implement structured logging
+- Forward logs to centralized system
+- Monitor container metrics
+- Implement proper health checks

--- a/.opencode/skills/github-workflow/SKILL.md
+++ b/.opencode/skills/github-workflow/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: github-workflow
+description: GitHub best practices for pull requests, code reviews, issues, Actions workflows, and repository management
+---
+
+# GitHub Workflow Best Practices
+
+You are an expert in GitHub workflows, including pull requests, code reviews, GitHub Actions, issue management, and repository best practices.
+
+## Core Principles
+
+- Use pull requests for all code changes to enable review and discussion
+- Automate workflows with GitHub Actions for CI/CD
+- Maintain clear issue tracking and project management
+- Follow security best practices for repository access and secrets
+- Document repositories thoroughly with README and contributing guidelines
+
+## Pull Request Best Practices
+
+### Creating Effective Pull Requests
+
+1. **Keep PRs small and focused**
+   - One feature or fix per PR
+   - Aim for under 400 lines of changes when possible
+   - Split large features into stacked PRs
+
+2. **Write descriptive PR titles**
+   - Use conventional commit style: `feat: add user authentication`
+   - Be specific about what the PR accomplishes
+
+3. **PR Description Template**
+   ```markdown
+   ## Summary
+   Brief description of changes and motivation.
+
+   ## Changes
+   - Bullet points of specific changes made
+
+   ## Testing
+   - How the changes were tested
+   - Steps to reproduce/verify
+
+   ## Related Issues
+   Closes #123
+
+   ## Screenshots (if applicable)
+   ```
+
+4. **Link related issues**
+   - Use `Closes #123` or `Fixes #123` to auto-close issues
+   - Reference related issues with `#123`
+
+### Stacked Pull Requests
+
+For complex features, use stacked PRs:
+
+1. Create a base feature branch
+2. Create subsequent PRs that build on each other
+3. Merge in order from base to top
+4. Keep each PR small and reviewable
+
+## Code Review Guidelines
+
+### As a Reviewer
+
+1. **Review promptly** - Respond within 24 hours when possible
+2. **Be constructive** - Focus on improvement, not criticism
+3. **Ask questions** - Seek to understand before suggesting changes
+4. **Prioritize feedback**:
+   - Blocking: Security issues, bugs, breaking changes
+   - Important: Performance, maintainability
+   - Nice-to-have: Style preferences, minor improvements
+
+### Comment Conventions
+
+Use prefixes to indicate comment severity:
+
+- `blocking:` Must be addressed before merge
+- `suggestion:` Recommended improvement
+- `question:` Seeking clarification
+- `nit:` Minor style or preference (optional to address)
+- `praise:` Positive feedback on good code
+
+### Example Review Comments
+
+```
+blocking: This SQL query is vulnerable to injection.
+Please use parameterized queries.
+
+suggestion: Consider extracting this logic into a separate
+function for better testability.
+
+nit: Prefer `const` over `let` here since this value
+is never reassigned.
+```
+
+### Approval Criteria
+
+- All blocking comments addressed
+- Tests pass
+- CI/CD checks pass
+- At least one approval from code owner
+
+## GitHub Actions
+
+### Workflow Best Practices
+
+1. **Use workflow templates**
+   ```yaml
+   name: CI
+   on:
+     push:
+       branches: [main]
+     pull_request:
+       branches: [main]
+
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - name: Setup Node.js
+           uses: actions/setup-node@v4
+           with:
+             node-version: '20'
+             cache: 'npm'
+         - run: npm ci
+         - run: npm test
+   ```
+
+2. **Cache dependencies**
+   ```yaml
+   - uses: actions/cache@v4
+     with:
+       path: ~/.npm
+       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+   ```
+
+3. **Use reusable workflows**
+   ```yaml
+   jobs:
+     call-workflow:
+       uses: ./.github/workflows/reusable.yml
+       with:
+         environment: production
+       secrets: inherit
+   ```
+
+4. **Set appropriate timeouts**
+   ```yaml
+   jobs:
+     build:
+       timeout-minutes: 10
+   ```
+
+### Security in Actions
+
+- Use `secrets` for sensitive data
+- Pin action versions with SHA: `uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29`
+- Limit `GITHUB_TOKEN` permissions
+- Review third-party actions before use
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+## Issue Management
+
+### Issue Templates
+
+Create `.github/ISSUE_TEMPLATE/` with templates:
+
+**Bug Report:**
+```markdown
+---
+name: Bug Report
+about: Report a bug
+labels: bug
+---
+
+## Description
+Clear description of the bug.
+
+## Steps to Reproduce
+1. Step one
+2. Step two
+
+## Expected Behavior
+What should happen.
+
+## Actual Behavior
+What actually happens.
+
+## Environment
+- OS:
+- Browser:
+- Version:
+```
+
+**Feature Request:**
+```markdown
+---
+name: Feature Request
+about: Suggest a new feature
+labels: enhancement
+---
+
+## Problem
+Describe the problem this feature would solve.
+
+## Proposed Solution
+Describe your proposed solution.
+
+## Alternatives Considered
+Other approaches you've considered.
+```
+
+### Labels
+
+Use consistent labels:
+- `bug`, `enhancement`, `documentation`
+- `good first issue`, `help wanted`
+- `priority: high`, `priority: medium`, `priority: low`
+- `status: in progress`, `status: blocked`
+
+## Repository Management
+
+### Branch Protection Rules
+
+Configure for main branch:
+- Require pull request reviews
+- Require status checks to pass
+- Require conversation resolution
+- Require signed commits (optional)
+- Restrict force pushes
+
+### CODEOWNERS File
+
+```
+# .github/CODEOWNERS
+* @default-team
+/docs/ @docs-team
+/src/api/ @backend-team
+*.js @frontend-team
+```
+
+### Security Best Practices
+
+1. **Enable security features**
+   - Dependabot alerts and updates
+   - Code scanning with CodeQL
+   - Secret scanning
+
+2. **Manage secrets properly**
+   - Use repository or organization secrets
+   - Rotate secrets regularly
+   - Never commit secrets to code
+
+3. **Access control**
+   - Use teams for permissions
+   - Follow principle of least privilege
+   - Audit access regularly
+
+## Automation Recommendations
+
+### Auto-merge for Dependabot
+
+```yaml
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Auto-merge minor updates
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Release Automation
+
+Use semantic-release or release-please for automated releases based on conventional commits.

--- a/.opencode/skills/learn-from-fix/MEMORY.md
+++ b/.opencode/skills/learn-from-fix/MEMORY.md
@@ -40,3 +40,19 @@
 - **Pattern**: Do NOT build Elixir releases inside Docker for Fly.io deployments. Build on the GitHub Actions runner (which has working OTP httpc), then use Docker with `ubuntu:24.04` to package the pre-built release.
 - **Why**: The OTP httpc TLS client fails inside Docker (`key_usage_mismatch` on `builds.hex.pm`) due to missing/broken CA bundle. The runner has no such issue. Also, `ubuntu:24.04` must match the runner's GLIBC version (2.39) to avoid "GLIBC not found" errors on the ERTS binary.
 - **Fix**: `.github/workflows/deploy.yml` — `mix deps.get && mix compile && mix assets.deploy && mix release` on runner, then `flyctl deploy --local-only` (uses Dockerfile to package the release artifact).
+
+### Lesson 6: GitHub Actions `_build` cache can distribute stale release artifacts
+- **Pattern**: Do NOT rely on `mix release` to fully overwrite a cached release directory. Even though `build_rel/1` deletes `releases/VERSION/`, the cached `_build/prod/rel/APP/` tree can reintroduce stale config files (`runtime.exs`, `sys.config`) if `mix release` skips or partially overwrites them.
+- **Why**: GitHub Actions caches the entire `_build/` directory keyed on `hashFiles('**/mix.lock')`. When `mix.lock` doesn't change between deploys (no deps added/removed), the previous release directory is restored. `mix release` does `File.rm_rf!(version_path)` and copies `config/runtime.exs` fresh via `File.cp!`, but in practice the cached files can persist — particularly when the workflow uses restore-keys fallback, which can match a cache from a markedly different build.
+- **Fix**: Clean the old release directory right before `mix release`:
+  ```yaml
+  - name: Clean old release to avoid stale config files
+    run: rm -rf _build/prod/rel/discuss/
+
+  - name: Build release
+    run: mix release
+  ```
+  Alternatively, include a commit hash or timestamp in the cache key to bust it on every deploy:
+  ```yaml
+  key: ${{ runner.os }}-build-prod-${{ hashFiles('**/mix.lock') }}-${{ github.sha }}
+  ```

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -61,10 +61,10 @@
   default: true;
   prefersdark: false;
   color-scheme: "light";
-  --color-base-100: oklch(98% 0 0);
-  --color-base-200: oklch(96% 0.001 286.375);
-  --color-base-300: oklch(92% 0.004 286.32);
-  --color-base-content: oklch(21% 0.006 285.885);
+  --color-base-100: oklch(96% 0.012 85);
+  --color-base-200: oklch(92% 0.016 85);
+  --color-base-300: oklch(87% 0.022 85);
+  --color-base-content: oklch(20% 0.012 85);
   --color-primary: oklch(70% 0.213 47.604);
   --color-primary-content: oklch(98% 0.016 73.684);
   --color-secondary: oklch(55% 0.027 264.364);
@@ -120,6 +120,30 @@ textarea:focus-visible {
 /* Fade in scale animation for toast */
 .fade-in-scale {
   transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+/* Auto-dismiss toasts: pop in, wait, then fade out */
+.toast > .alert {
+  animation: toast-pop 0.3s ease-out, toast-fade 0.5s ease-in 3s forwards;
+}
+
+@keyframes toast-pop {
+  from {
+    opacity: 0;
+    transform: translateY(-0.5rem) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toast-fade {
+  to {
+    opacity: 0;
+    transform: translateY(-0.5rem) scale(0.95);
+    pointer-events: none;
+  }
 }
 
 /* This file is for your main application CSS */

--- a/lib/discuss/discussions.ex
+++ b/lib/discuss/discussions.ex
@@ -17,7 +17,7 @@ defmodule Discuss.Discussions do
   """
   def list_topics do
     Topic
-    |> preload(:user)
+    |> preload([:user, comments: [:user]])
     |> order_by([t], desc: t.inserted_at)
     |> Repo.all()
   end
@@ -179,7 +179,7 @@ defmodule Discuss.Discussions do
   end
 
   defp broadcast_topic({:ok, topic} = result, event) do
-    topic = Repo.preload(topic, :user)
+    topic = Repo.preload(topic, [:user, comments: [:user]])
 
     Phoenix.PubSub.broadcast(Discuss.PubSub, "topics", {event, topic})
 

--- a/lib/discuss_web/components/layouts/app.html.heex
+++ b/lib/discuss_web/components/layouts/app.html.heex
@@ -3,7 +3,7 @@
     <div class="flex justify-between h-16 items-center">
       <.link
         navigate={~p"/"}
-        class="text-xl font-bold text-base-content hover:text-primary transition-colors"
+        class="text-3xl font-bold text-base-content hover:text-primary transition-colors"
       >
         <span class="sm:hidden">💬</span>
         <span class="hidden sm:inline">💬 Discuss</span>
@@ -13,38 +13,43 @@
         <.theme_toggle />
 
         <%= if @current_user do %>
-          <div class="flex items-center gap-2 sm:gap-3">
-            <img
-              :if={@current_user.avatar_url}
-              src={@current_user.avatar_url}
-              alt={@current_user.name || @current_user.email}
-              class="w-8 h-8 rounded-full shrink-0"
-            />
-            <div
-              :if={!@current_user.avatar_url}
-              class="w-8 h-8 rounded-full bg-primary text-primary-content flex items-center justify-center text-sm font-semibold shrink-0"
-            >
-              {String.first(@current_user.name || @current_user.email) |> String.upcase()}
-            </div>
-            <span class="hidden sm:inline text-sm font-medium text-base-content/80 truncate max-w-[150px]">
-              {@current_user.name || @current_user.email}
-            </span>
-            <.link
-              href="/auth/signout"
-              method="delete"
-              class="text-sm text-base-content/60 hover:text-base-content transition-colors"
-              aria-label="Sign out"
-            >
-              Sign Out
-            </.link>
-          </div>
+          <details class="dropdown dropdown-end">
+            <summary class="list-none cursor-pointer">
+              <img
+                :if={@current_user.avatar_url}
+                src={@current_user.avatar_url}
+                alt={@current_user.name || @current_user.email}
+                class="w-8 h-8 rounded-full shrink-0"
+              />
+              <div
+                :if={!@current_user.avatar_url}
+                class="w-8 h-8 rounded-full bg-primary text-primary-content flex items-center justify-center text-lg font-semibold shrink-0"
+              >
+                {String.first(@current_user.name || @current_user.email) |> String.upcase()}
+              </div>
+            </summary>
+            <ul class="dropdown-content menu bg-base-100 rounded-box z-50 shadow-lg mt-2 p-2 w-48 border border-base-300">
+              <li class="menu-title">
+                <span>{@current_user.name || @current_user.email}</span>
+              </li>
+              <li>
+                <.link
+                  href="/auth/signout"
+                  method="delete"
+                  class="text-error hover:text-error/80"
+                >
+                  Sign Out
+                </.link>
+              </li>
+            </ul>
+          </details>
         <% else %>
           <.link
             href="/auth/github"
-            class="inline-flex items-center px-3 sm:px-4 py-2 border border-transparent text-xs sm:text-sm font-medium rounded-md text-neutral-content bg-neutral hover:bg-neutral/80 transition-colors"
+            class="btn btn-soft btn-sm gap-1.5"
             aria-label="Sign in with GitHub"
           >
-            <span class="hidden sm:inline">Sign in with </span>GitHub
+            <.icon name="hero-github" class="size-4" /> Sign in
           </.link>
         <% end %>
       </div>
@@ -53,7 +58,7 @@
 </nav>
 
 <main class="px-4 py-6 sm:py-8 sm:px-6 lg:px-8">
-  <div class="mx-auto max-w-4xl space-y-6">
+  <div class="mx-auto max-w-6xl space-y-6">
     {@inner_content}
   </div>
 </main>

--- a/lib/discuss_web/live/topic_live/index.ex
+++ b/lib/discuss_web/live/topic_live/index.ex
@@ -10,11 +10,19 @@ defmodule DiscussWeb.TopicLive.Index do
     # so they need the data. This is the SEO exception to the async rule.
     topics = Discussions.list_topics()
 
-    if connected?(socket), do: Discussions.subscribe_to_topics()
+    if connected?(socket) do
+      Discussions.subscribe_to_topics()
+
+      # Subscribe to each topic's channel for comment updates
+      for topic <- topics do
+        Discussions.subscribe_to_topic(topic.id)
+      end
+    end
 
     {:ok,
      socket
      |> assign(:loading, false)
+     |> assign(:editing_topic_id, nil)
      |> stream(:topics, topics)
      |> assign_create_form()}
   end
@@ -22,27 +30,6 @@ defmodule DiscussWeb.TopicLive.Index do
   @impl true
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
-  end
-
-  defp apply_action(socket, :edit, %{"id" => id}) do
-    case Discussions.get_topic(id) do
-      nil ->
-        socket
-        |> put_flash(:error, "Topic not found")
-        |> push_navigate(to: ~p"/topics")
-
-      topic ->
-        if socket.assigns.current_user &&
-             socket.assigns.current_user.id == topic.user_id do
-          socket
-          |> assign(:page_title, "Edit Topic")
-          |> assign(:topic, topic)
-        else
-          socket
-          |> put_flash(:error, "You can only edit your own topics")
-          |> push_navigate(to: ~p"/topics")
-        end
-    end
   end
 
   defp apply_action(socket, :index, _params) do
@@ -75,11 +62,16 @@ defmodule DiscussWeb.TopicLive.Index do
   end
 
   @impl true
-  def handle_info({DiscussWeb.TopicLive.FormComponent, {:saved, topic}}, socket) do
-    # The FormComponent fires notify_parent on edit.
-    # The topic was already broadcast via update_topic/2 so the stream is already updated,
-    # but this ensures the parent side-effects (flash navigation) still occur.
-    # The duplicate stream_insert is a no-op since the DOM ID already exists.
+  def handle_info({:comment_created, comment}, socket) do
+    # Re-fetch the topic with comments preloaded and re-stream
+    topic = Discussions.get_topic!(comment.topic_id)
+    {:noreply, stream_insert(socket, :topics, topic)}
+  end
+
+  @impl true
+  def handle_info({:comment_deleted, comment}, socket) do
+    # Re-fetch the topic with comments preloaded and re-stream
+    topic = Discussions.get_topic!(comment.topic_id)
     {:noreply, stream_insert(socket, :topics, topic)}
   end
 
@@ -103,6 +95,87 @@ defmodule DiscussWeb.TopicLive.Index do
   end
 
   @impl true
+  def handle_event("start_edit", %{"id" => topic_id}, socket) do
+    topic = Discussions.get_topic!(topic_id)
+
+    {:noreply,
+     socket
+     |> assign(:editing_topic_id, topic_id)
+     |> stream_insert(:topics, topic)}
+  end
+
+  @impl true
+  def handle_event("save_edit", %{"topic_id" => topic_id_str, "title" => title}, socket) do
+    topic_id =
+      case Integer.parse(topic_id_str) do
+        {parsed, _} -> parsed
+        :error -> topic_id_str
+      end
+
+    case Discussions.get_topic(topic_id) do
+      nil ->
+        {:noreply,
+         socket
+         |> assign(:editing_topic_id, nil)
+         |> put_flash(:error, "Topic not found")}
+
+      topic ->
+        case Discussions.update_topic_by_user(socket.assigns.current_user, topic, %{
+               "title" => title
+             }) do
+          {:ok, updated_topic} ->
+            topic = Discussions.get_topic!(updated_topic.id)
+
+            {:noreply,
+             socket
+             |> assign(:editing_topic_id, nil)
+             |> stream_insert(:topics, topic)
+             |> put_flash(:info, "Topic updated!")}
+
+          {:error, :unauthorized} ->
+            topic = Discussions.get_topic!(topic_id)
+
+            {:noreply,
+             socket
+             |> assign(:editing_topic_id, nil)
+             |> stream_insert(:topics, topic)
+             |> put_flash(:error, "You can only edit your own topics")}
+
+          {:error, %Ecto.Changeset{} = changeset} ->
+            message =
+              changeset
+              |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+                Regex.replace(~r/%\{(\w+)\}/, msg, fn _, key ->
+                  opts[String.to_existing_atom(key)] |> to_string()
+                end)
+              end)
+              |> Enum.map(fn {key, msgs} -> "#{key}: #{Enum.join(msgs, ", ")}" end)
+              |> Enum.join("; ")
+
+            {:noreply,
+             socket
+             |> assign(:editing_topic_id, nil)
+             |> put_flash(:error, message)}
+        end
+    end
+  end
+
+  @impl true
+  def handle_event("cancel_edit", _params, socket) do
+    topic_id = socket.assigns.editing_topic_id
+
+    socket =
+      if topic_id do
+        topic = Discussions.get_topic!(topic_id)
+        stream_insert(socket, :topics, topic)
+      else
+        socket
+      end
+
+    {:noreply, assign(socket, :editing_topic_id, nil)}
+  end
+
+  @impl true
   def handle_event("delete", %{"id" => id}, socket) do
     case Discussions.get_topic(id) do
       nil ->
@@ -115,6 +188,31 @@ defmodule DiscussWeb.TopicLive.Index do
 
           {:error, :unauthorized} ->
             {:noreply, put_flash(socket, :error, "You can only delete your own topics")}
+        end
+    end
+  end
+
+  @impl true
+  def handle_event("create_comment", %{"topic-id" => topic_id, "content" => content}, socket) do
+    case Discussions.get_topic(topic_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Topic not found")}
+
+      topic ->
+        case Discussions.create_comment(socket.assigns.current_user, topic, %{
+               "content" => content
+             }) do
+          {:ok, _comment} ->
+            # Re-fetch topic with comments preloaded and re-stream
+            topic = Discussions.get_topic!(topic_id)
+
+            {:noreply,
+             socket
+             |> stream_insert(:topics, topic)
+             |> put_flash(:info, "Comment added!")}
+
+          {:error, _changeset} ->
+            {:noreply, put_flash(socket, :error, "Could not add comment")}
         end
     end
   end

--- a/lib/discuss_web/live/topic_live/index.html.heex
+++ b/lib/discuss_web/live/topic_live/index.html.heex
@@ -1,7 +1,3 @@
-<.header>
-  Topics
-</.header>
-
 <!-- Inline Composer — Facebook-style -->
 <div
   :if={@current_user}
@@ -27,7 +23,7 @@
         value={Phoenix.HTML.Form.normalize_value("text", @create_form[:title].value)}
         placeholder="What do you want to discuss?"
         autocomplete="off"
-        class="w-full bg-base-200 border-0 focus:ring-0 rounded-xl px-4 py-2.5 text-sm placeholder:text-base-content/40 outline-none"
+        class="w-full bg-base-200 border-0 focus:ring-0 rounded-xl px-4 py-2.5 text-lg placeholder:text-base-content/40 outline-none"
       />
       <.button class="shrink-0">Post</.button>
     </div>
@@ -41,7 +37,7 @@
 >
   <div class="flex items-center gap-3">
     <div class="w-10 h-10 rounded-full bg-base-300 shrink-0" />
-    <p class="flex-1 text-left text-base-content/50">
+    <p class="flex-1 text-left text-base-content/50 text-lg">
       <.link href="/auth/github" class="text-primary hover:text-primary-focus font-medium">
         Sign in
       </.link>
@@ -50,71 +46,166 @@
   </div>
 </div>
 
-<div class="mt-6 space-y-3" id="topics" phx-update="stream">
+<div class="space-y-3" id="topics" phx-update="stream">
   <!-- Empty State (only shown when this is the only child) -->
   <div id="topics-empty" class="hidden only:flex only:flex-col only:items-center only:py-12">
     <.icon name="hero-chat-bubble-left-right" class="mx-auto h-12 w-12 text-base-content/40" />
-    <h3 class="mt-4 text-base font-medium text-base-content">No topics yet</h3>
-    <p class="mt-1 text-sm text-base-content/50">Be the first to start a discussion!</p>
+    <h3 class="mt-4 text-lg font-medium text-base-content">No topics yet</h3>
+    <p class="mt-1 text-base text-base-content/50">Be the first to start a discussion!</p>
   </div>
   <div
     :for={{id, topic} <- @streams.topics}
     id={id}
-    class="bg-base-100 shadow-sm hover:shadow-md border border-base-300 transition-all duration-200 rounded-xl p-5 sm:p-6"
+    class="group bg-base-100 shadow-sm hover:shadow-md border border-base-300 transition-all duration-200 rounded-xl p-6 sm:p-8"
   >
-    <div class="flex items-start justify-between gap-4">
-      <div class="flex-1 min-w-0">
-        <.link
-          navigate={~p"/topics/#{topic}"}
-          class="text-base sm:text-lg font-semibold text-base-content hover:text-primary transition-colors"
+    <%= if @editing_topic_id == topic.id do %>
+      <%!-- Edit mode: inline title edit form --%>
+      <form phx-submit="save_edit">
+        <input type="hidden" name="topic_id" value={topic.id} />
+        <div class="flex items-center gap-2">
+          <input
+            id={"edit-title-input-#{topic.id}"}
+            type="text"
+            name="title"
+            value={topic.title}
+            autocomplete="off"
+            phx-hook=".TitleEditFocus"
+            phx-keydown="cancel_edit"
+            phx-key="Escape"
+            class="w-full bg-base-200 border-0 focus:ring-2 focus:ring-primary rounded-xl px-4 py-2 text-2xl sm:text-3xl font-semibold outline-none"
+          />
+          <.button class="shrink-0 btn-sm">Save</.button>
+          <button
+            type="button"
+            phx-click="cancel_edit"
+            class="text-sm text-base-content/50 hover:text-base-content transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    <% else %>
+      <%!-- View mode: title + metadata + comment preview (navigable areas highlighted on hover) --%>
+      <div class="flex items-start justify-between gap-4">
+        <div class="flex-1 min-w-0">
+          <%!-- Owner: title edits (outside nav link, no hover highlight) --%>
+          <div
+            :if={@current_user && @current_user.id == topic.user_id}
+            class="flex items-center gap-2"
+          >
+            <span
+              phx-click={JS.push("start_edit", value: %{id: topic.id})}
+              class="text-2xl sm:text-3xl font-semibold text-base-content hover:text-primary transition-colors line-clamp-2 cursor-pointer"
+            >
+              {topic.title}
+            </span>
+          </div>
+
+          <%!-- Navigable area: title (non-owner) + metadata + comment preview --%>
+          <.link navigate={~p"/topics/#{topic}"} class="block rounded-lg -mx-1 px-1 py-0.5 hover:bg-base-200/40 transition-colors duration-200">
+            <span
+              :if={!@current_user || @current_user.id != topic.user_id}
+              class="text-2xl sm:text-3xl font-semibold text-base-content line-clamp-2"
+            >
+              {topic.title}
+            </span>
+            <p class="mt-1.5 text-lg text-base-content/60">
+              Created by {topic.user.name || topic.user.email} · {Calendar.strftime(
+                topic.inserted_at,
+                "%B %d, %Y"
+              )}
+            </p>
+            <%!-- Comments preview --%>
+            <div :if={topic.comments != []} class="mt-4 pt-4 border-t border-base-300">
+              <div :for={comment <- Enum.take(topic.comments, 2)} class="flex gap-2.5 mb-2.5">
+                <img
+                  :if={comment.user && comment.user.avatar_url}
+                  src={comment.user.avatar_url}
+                  alt={comment.user.name || comment.user.email}
+                  class="w-6 h-6 rounded-full shrink-0 mt-0.5"
+                />
+                <div
+                  :if={comment.user && !comment.user.avatar_url}
+                  class="w-6 h-6 rounded-full bg-base-300 shrink-0 mt-0.5 flex items-center justify-center text-[10px] font-semibold"
+                >
+                  {String.first(comment.user.name || comment.user.email) |> String.upcase()}
+                </div>
+                <div class="min-w-0">
+                  <span class="text-base font-medium text-base-content/80">
+                    {comment.user.name || comment.user.email}
+                  </span>
+                  <p class="text-lg text-base-content/70 break-words">{comment.content}</p>
+                </div>
+              </div>
+              <p
+                :if={length(topic.comments) > 2}
+                class="text-base text-primary hover:text-primary-focus font-medium"
+              >
+                View all {length(topic.comments)} comments →
+              </p>
+            </div>
+          </.link>
+        </div>
+
+        <div
+          :if={@current_user && @current_user.id == topic.user_id}
+          class="flex gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
         >
-          {topic.title}
-        </.link>
-        <p class="mt-1.5 text-sm text-base-content/60">
-          Created by {topic.user.name || topic.user.email} · {Calendar.strftime(
-            topic.inserted_at,
-            "%B %d, %Y"
-          )}
-        </p>
+          <button
+            class="p-1.5 rounded-lg hover:bg-error/10 text-base-content/40 hover:text-error transition-colors"
+            phx-click={
+              JS.push("delete", value: %{id: topic.id})
+              |> JS.transition("fade-out-scale", to: "##{id}")
+            }
+            data-confirm="Are you sure you want to delete this topic? All comments will be permanently lost."
+            aria-label="Delete topic"
+          >
+            <.icon name="hero-trash" class="size-4" />
+          </button>
+        </div>
       </div>
 
-      <div
-        :if={@current_user && @current_user.id == topic.user_id}
-        class="flex gap-2 shrink-0"
-      >
-        <.link patch={~p"/topics/#{topic}/edit"}>
-          <.button variant="secondary">Edit</.button>
-        </.link>
-        <.button
-          variant="danger"
-          phx-click={
-            JS.push("delete", value: %{id: topic.id})
-            |> JS.transition("fade-out-scale", to: "##{id}")
-          }
-          data-confirm="Are you sure you want to delete this topic? All comments will be permanently lost."
-          aria-label="Delete topic"
+      <%!-- Inline comment form --%>
+      <div :if={@current_user} class="mt-4 pt-4 border-t border-base-300">
+        <.form
+          id={"comment-form-#{topic.id}"}
+          for={%{"content" => ""}}
+          phx-submit="create_comment"
+          phx-value-topic-id={topic.id}
         >
-          Delete
-        </.button>
+          <div class="flex items-center gap-2.5">
+            <img
+              :if={@current_user.avatar_url}
+              src={@current_user.avatar_url}
+              alt={@current_user.name || @current_user.email}
+              class="w-6 h-6 rounded-full shrink-0"
+            />
+            <div
+              :if={!@current_user.avatar_url}
+              class="w-6 h-6 rounded-full bg-primary text-primary-content flex items-center justify-center text-[10px] font-semibold shrink-0"
+            >
+              {String.first(@current_user.name || @current_user.email) |> String.upcase()}
+            </div>
+            <input
+              type="text"
+              name="content"
+              placeholder="Write a comment..."
+              autocomplete="off"
+              class="flex-1 bg-base-200 border-0 focus:ring-0 rounded-full px-4 py-1.5 text-lg placeholder:text-base-content/40 outline-none"
+            />
+            <.button class="shrink-0 btn-sm">Reply</.button>
+          </div>
+        </.form>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>
 
-<!-- Edit Modal (only, no new-topic modal) -->
-<.modal
-  :if={@live_action == :edit}
-  id="topic-modal"
-  show
-  on_cancel={JS.patch(~p"/topics")}
->
-  <.live_component
-    module={DiscussWeb.TopicLive.FormComponent}
-    id={@topic.id}
-    title={@page_title}
-    action={@live_action}
-    topic={@topic}
-    current_user={@current_user}
-    patch={~p"/topics"}
-  />
-</.modal>
+<script :type={Phoenix.LiveView.ColocatedHook} name=".TitleEditFocus">
+  export default {
+    mounted() {
+      this.el.focus()
+      this.el.select()
+    }
+  }
+</script>

--- a/lib/discuss_web/live/topic_live/show.ex
+++ b/lib/discuss_web/live/topic_live/show.ex
@@ -24,10 +24,83 @@ defmodule DiscussWeb.TopicLive.Show do
          socket
          |> assign(:topic, topic)
          |> assign(:page_title, topic.title)
+         |> assign(:editing, false)
          |> assign(:comments_count, comments_count)
          |> stream(:comments, topic.comments)
          |> assign_comment_form()}
     end
+  end
+
+  @impl true
+  def handle_event("start_edit", %{"id" => _topic_id}, socket) do
+    {:noreply, assign(socket, :editing, true)}
+  end
+
+  @impl true
+  def handle_event("save_edit", %{"topic_id" => topic_id_str, "title" => title}, socket) do
+    topic_id =
+      case Integer.parse(topic_id_str) do
+        {parsed, _} -> parsed
+        :error -> topic_id_str
+      end
+
+    case Discussions.get_topic(topic_id) do
+      nil ->
+        {:noreply,
+         socket
+         |> assign(:editing, false)
+         |> put_flash(:error, "Topic not found")}
+
+      topic ->
+        case Discussions.update_topic_by_user(socket.assigns.current_user, topic, %{
+               "title" => title
+             }) do
+          {:ok, updated_topic} ->
+            topic = Discussions.get_topic!(updated_topic.id)
+            comments_count = length(topic.comments)
+
+            {:noreply,
+             socket
+             |> assign(:topic, topic)
+             |> assign(:editing, false)
+             |> assign(:page_title, topic.title)
+             |> assign(:comments_count, comments_count)
+             |> stream(:comments, topic.comments, reset: true)
+             |> put_flash(:info, "Topic updated!")}
+
+          {:error, :unauthorized} ->
+            topic = Discussions.get_topic!(topic_id)
+            comments_count = length(topic.comments)
+
+            {:noreply,
+             socket
+             |> assign(:topic, topic)
+             |> assign(:editing, false)
+             |> assign(:comments_count, comments_count)
+             |> put_flash(:error, "You can only edit your own topics")}
+
+          {:error, %Ecto.Changeset{} = changeset} ->
+            message =
+              changeset
+              |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+                Regex.replace(~r/%\{(\w+)\}/, msg, fn _, key ->
+                  opts[String.to_existing_atom(key)] |> to_string()
+                end)
+              end)
+              |> Enum.map(fn {key, msgs} -> "#{key}: #{Enum.join(msgs, ", ")}" end)
+              |> Enum.join("; ")
+
+            {:noreply,
+             socket
+             |> assign(:editing, false)
+             |> put_flash(:error, message)}
+        end
+    end
+  end
+
+  @impl true
+  def handle_event("cancel_edit", _params, socket) do
+    {:noreply, assign(socket, :editing, false)}
   end
 
   @impl true

--- a/lib/discuss_web/live/topic_live/show.html.heex
+++ b/lib/discuss_web/live/topic_live/show.html.heex
@@ -1,34 +1,82 @@
-<.header>
-  {@topic.title}
-  <:subtitle>
-    Created by {@topic.user.name || @topic.user.email} on {Calendar.strftime(
-      @topic.inserted_at,
-      "%B %d, %Y"
-    )}
-  </:subtitle>
-  <:actions>
-    <.link
-      :if={@current_user && @current_user.id == @topic.user_id}
-      patch={~p"/topics/#{@topic}/show/edit"}
-      phx-click={JS.push_focus()}
-    >
-      <.button>Edit topic</.button>
-    </.link>
-  </:actions>
-</.header>
+<div class="flex items-start justify-between gap-4 mb-6">
+  <div class="flex-1 min-w-0">
+    <%= if @editing do %>
+      <form phx-submit="save_edit">
+        <input type="hidden" name="topic_id" value={@topic.id} />
+        <div class="flex items-center gap-2">
+          <input
+            id="edit-title-input"
+            type="text"
+            name="title"
+            value={@topic.title}
+            autocomplete="off"
+            phx-hook=".TitleEditFocus"
+            phx-keydown="cancel_edit"
+            phx-key="Escape"
+            class="w-full bg-base-200 border-0 focus:ring-2 focus:ring-primary rounded-xl px-4 py-2 text-2xl sm:text-3xl font-bold outline-none"
+          />
+          <.button class="shrink-0 btn-sm">Save</.button>
+          <button
+            type="button"
+            phx-click="cancel_edit"
+            class="text-sm text-base-content/50 hover:text-base-content transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    <% else %>
+      <h1
+        :if={@current_user && @current_user.id == @topic.user_id}
+        phx-click={JS.push("start_edit", value: %{id: @topic.id})}
+        class="text-2xl sm:text-3xl font-bold text-base-content hover:text-primary transition-colors cursor-pointer"
+      >
+        {@topic.title}
+      </h1>
+      <h1
+        :if={!@current_user || @current_user.id != @topic.user_id}
+        class="text-2xl sm:text-3xl font-bold text-base-content"
+      >
+        {@topic.title}
+      </h1>
+    <% end %>
+    <p class="mt-1 text-lg text-base-content/60">
+      Created by {@topic.user.name || @topic.user.email} on {Calendar.strftime(
+        @topic.inserted_at,
+        "%B %d, %Y"
+      )}
+    </p>
+  </div>
+</div>
 
 <div class="mt-8">
-  <h2 class="text-2xl font-bold text-base-content mb-4">Comments</h2>
+  <h2 class="text-3xl font-bold text-base-content mb-4">Comments</h2>
 
-  <div :if={@current_user} class="mb-8 bg-base-100 shadow rounded-lg p-6">
+  <div :if={@current_user} class="mb-8 bg-base-100 shadow rounded-lg p-6 sm:p-8">
     <.simple_form for={@comment_form} phx-submit="save_comment">
       <.input
         field={@comment_form[:content]}
         type="textarea"
-        phx-hook="AutoFocus"
+        phx-hook=".CommentInput"
         label="Add a comment"
         rows="3"
       />
+      <script :type={Phoenix.LiveView.ColocatedHook} name=".CommentInput">
+        export default {
+          mounted() {
+            this.el.focus()
+            this.el.addEventListener("keydown", e => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault()
+                this.el.form.requestSubmit()
+              }
+            })
+            this.el.form.addEventListener("submit", () => {
+              setTimeout(() => { this.el.value = "" }, 0)
+            })
+          }
+        }
+      </script>
       <:actions>
         <.button phx-disable-with="Posting...">Post Comment</.button>
       </:actions>
@@ -41,8 +89,8 @@
       name="hero-chat-bubble-oval-left-ellipsis"
       class="mx-auto h-12 w-12 text-base-content/50"
     />
-    <h3 class="mt-2 text-sm font-medium text-base-content">No comments yet</h3>
-    <p class="mt-1 text-sm text-base-content/60">Be the first to share your thoughts!</p>
+    <h3 class="mt-2 text-lg font-medium text-base-content">No comments yet</h3>
+    <p class="mt-1 text-base text-base-content/60">Be the first to share your thoughts!</p>
   </div>
   
 <!-- Comments List with Auto-scroll -->
@@ -69,18 +117,18 @@
               />
               <div
                 :if={!comment.user.avatar_url}
-                class="w-8 h-8 rounded-full bg-primary text-primary-content flex items-center justify-center text-xs font-semibold shrink-0"
+                class="w-8 h-8 rounded-full bg-primary text-primary-content flex items-center justify-center text-sm font-semibold shrink-0"
               >
                 {String.first(comment.user.name || comment.user.email) |> String.upcase()}
               </div>
-              <span class="font-semibold text-base-content truncate">
+              <span class="text-lg font-semibold text-base-content truncate">
                 {comment.user.name || comment.user.email}
               </span>
-              <span class="text-sm text-base-content/60 whitespace-nowrap">
+              <span class="text-base text-base-content/60 whitespace-nowrap">
                 {Calendar.strftime(comment.inserted_at, "%B %d, %Y at %I:%M %p")}
               </span>
             </div>
-            <p class="text-base-content/80 whitespace-pre-wrap">{comment.content}</p>
+            <p class="text-lg text-base-content/80 whitespace-pre-wrap">{comment.content}</p>
           </div>
 
           <button
@@ -91,7 +139,7 @@
             }
             data-confirm="Are you sure you want to delete this comment?"
             aria-label="Delete comment"
-            class="ml-4 text-error hover:text-error/80 shrink-0"
+            class="ml-4 text-lg text-error hover:text-error/80 shrink-0"
           >
             Delete
           </button>
@@ -103,19 +151,11 @@
 
 <.back navigate={~p"/topics"}>Back to topics</.back>
 
-<.modal
-  :if={@live_action == :edit}
-  id="topic-modal"
-  show
-  on_cancel={JS.patch(~p"/topics/#{@topic}")}
->
-  <.live_component
-    module={DiscussWeb.TopicLive.FormComponent}
-    id={@topic.id}
-    title={@page_title}
-    action={@live_action}
-    topic={@topic}
-    current_user={@current_user}
-    patch={~p"/topics/#{@topic}"}
-  />
-</.modal>
+<script :type={Phoenix.LiveView.ColocatedHook} name=".TitleEditFocus">
+  export default {
+    mounted() {
+      this.el.focus()
+      this.el.select()
+    }
+  }
+</script>

--- a/lib/discuss_web/router.ex
+++ b/lib/discuss_web/router.ex
@@ -25,8 +25,6 @@ defmodule DiscussWeb.Router do
     live "/", TopicLive.Index, :index
     live "/topics", TopicLive.Index, :index
     live "/topics/new", TopicLive.Index, :new
-    live "/topics/:id/edit", TopicLive.Index, :edit
-    live "/topics/:id/show/edit", TopicLive.Show, :edit
     live "/topics/:id", TopicLive.Show, :show
   end
 

--- a/test/discuss_web/live/topic_live_test.exs
+++ b/test/discuss_web/live/topic_live_test.exs
@@ -12,7 +12,7 @@ defmodule DiscussWeb.TopicLiveTest do
 
       {:ok, index_live, _html} = live(conn, ~p"/topics")
 
-      assert has_element?(index_live, "#topics a", topic.title)
+      assert has_element?(index_live, "#topics span", topic.title)
     end
 
     test "shows empty state when no topics exist", %{conn: conn} do
@@ -59,11 +59,11 @@ defmodule DiscussWeb.TopicLiveTest do
 
       # Simulate another user creating a topic via PubSub broadcast
       {:ok, topic} = Discussions.create_topic(user, %{title: "Real-time topic"})
-      topic = Repo.preload(topic, :user)
+      topic = Repo.preload(topic, [:user, :comments])
 
       send(index_live.pid, {:topic_created, topic})
 
-      assert has_element?(index_live, "#topics a", "Real-time topic")
+      assert has_element?(index_live, "#topics span", "Real-time topic")
     end
 
     test "real-time delete when a topic is deleted", %{conn: conn} do
@@ -72,15 +72,15 @@ defmodule DiscussWeb.TopicLiveTest do
       {:ok, index_live, _html} = live(conn, ~p"/topics")
 
       # Verify the topic is visible first
-      assert has_element?(index_live, "#topics a", topic.title)
+      assert has_element?(index_live, "#topics span", topic.title)
 
       # Simulate another user deleting the topic via PubSub broadcast
       {:ok, deleted} = Discussions.delete_topic(topic)
-      deleted = Repo.preload(deleted, :user)
+      deleted = Repo.preload(deleted, [:user, :comments])
 
       send(index_live.pid, {:topic_deleted, deleted})
 
-      refute has_element?(index_live, "#topics a", topic.title)
+      refute has_element?(index_live, "#topics span", topic.title)
     end
 
     test "real-time update when a topic title changes", %{conn: conn} do
@@ -90,11 +90,11 @@ defmodule DiscussWeb.TopicLiveTest do
 
       # Simulate topic being updated by another user via PubSub broadcast
       {:ok, updated} = Discussions.update_topic(topic, %{title: "Updated from broadcast"})
-      updated = Repo.preload(updated, :user)
+      updated = Repo.preload(updated, [:user, :comments])
 
       send(index_live.pid, {:topic_updated, updated})
 
-      assert has_element?(index_live, "#topics a", "Updated from broadcast")
+      assert has_element?(index_live, "#topics span", "Updated from broadcast")
     end
 
     test "real-time update when topic is not in stream yet", %{conn: conn} do
@@ -110,11 +110,11 @@ defmodule DiscussWeb.TopicLiveTest do
         }
         |> Repo.insert!()
 
-      topic = Repo.preload(topic, :user)
+      topic = Repo.preload(topic, [:user, :comments])
 
       send(index_live.pid, {:topic_created, topic})
 
-      assert has_element?(index_live, "#topics a", "Brand new topic")
+      assert has_element?(index_live, "#topics span", "Brand new topic")
     end
 
     test "shows inline composer for authenticated user", %{conn: conn} do
@@ -147,11 +147,36 @@ defmodule DiscussWeb.TopicLiveTest do
       |> form("#create-topic-form", topic: %{title: "Posted via composer"})
       |> render_submit()
 
-      assert has_element?(index_live, "#topics a", "Posted via composer")
+      assert has_element?(index_live, "#topics span", "Posted via composer")
     end
   end
 
-  describe "Show - Real-time updates" do
+  describe "Show" do
+    test "owner can edit topic title inline", %{conn: conn} do
+      user = user_fixture()
+      topic = topic_fixture(user)
+      updated_title = "Updated title - #{System.unique_integer([:positive])}"
+
+      conn = init_test_session(conn, user_id: user.id)
+
+      {:ok, show_live, _html} = live(conn, ~p"/topics/#{topic}")
+
+      # Start editing by clicking the title
+      show_live |> element("h1", topic.title) |> render_click()
+
+      # Now submit the updated title via the form
+      show_live
+      |> form("form[phx-submit=save_edit]", %{topic_id: topic.id, title: updated_title})
+      |> render_submit()
+
+      assert has_element?(show_live, "h1", updated_title)
+      assert render(show_live) =~ "Topic updated!"
+
+      # Verify the change persisted in the database
+      updated = Discussions.get_topic!(topic.id)
+      assert updated.title == updated_title
+    end
+
     test "receives real-time comment updates", %{conn: conn} do
       user = user_fixture()
       topic = topic_fixture()


### PR DESCRIPTION
Inline editing (no modals):
- Click owner title on Index → inline input with Save/Cancel
- Click owner title on Show → inline input with Save/Cancel
- Auto-focus + select all via  colocated hook
- Escape key cancels edit
- Validation errors shown as flash messages

Real-time comment updates on Index:
- PubSub subscriptions per topic for comment created/deleted
-  re-fetches topic with comments preloaded
- Eager preload comments:[:user] in list_topics and broadcasts

Card navigation:
- Non-owner title, metadata, and comment preview wrapped in navigate link
- hover:bg-base-200/40 highlight only on navigable area
- Owner title stays outside link (click-to-edit, no nav highlight)

UI polish:
- Warm cream-based palette (hue 85) — base-100/200/300, base-content
- Bigger text throughout (text-2xl/3xl titles, text-lg body)
- max-w-6xl container for wider layout
- Comment textarea: Enter submits, Shift+Enter newline (.CommentInput hook)
- Comment textarea auto-clears after post
- User dropdown menu with avatar trigger and sign out link
- Flash toasts auto-dismiss with pop-in/fade-out CSS animations
- GitHub sign in button uses icon + btn-soft style
- Removed FormComponent, modal routes (/topics/:id/edit, /topics/:id/show/edit)

Tests:
- Show page save_edit inline editing test
- Selectors updated from a to span for topic titles