### PR TITLE
fix: add nil-user guard to create_comment/3 and make user_id non-nullable (#30)

### DIFF
--- a/lib/discuss/discussions.ex
+++ b/lib/discuss/discussions.ex
@@ -125,7 +125,11 @@ defmodule Discuss.Discussions do
 
   @doc """
   Creates a new comment and broadcasts to connected users.
+  Returns `{:ok, comment}` on success, `{:error, changeset}` on validation failure,
+  or `{:error, :unauthorized}` if no user is provided.
   """
+  def create_comment(nil, _topic, _attrs), do: {:error, :unauthorized}
+
   def create_comment(user, topic, attrs) do
     topic
     |> Ecto.build_assoc(:comments)

--- a/lib/discuss_web/live/topic_live/index.ex
+++ b/lib/discuss_web/live/topic_live/index.ex
@@ -216,8 +216,11 @@ defmodule DiscussWeb.TopicLive.Index do
              |> stream_insert(:topics, topic)
              |> put_flash(:info, "Comment added!")}
 
-          {:error, _changeset} ->
+          {:error, %Ecto.Changeset{}} ->
             {:noreply, put_flash(socket, :error, "Could not add comment")}
+
+          {:error, :unauthorized} ->
+            {:noreply, put_flash(socket, :error, "You must be signed in to comment")}
         end
     end
   end

--- a/lib/discuss_web/live/topic_live/show.ex
+++ b/lib/discuss_web/live/topic_live/show.ex
@@ -123,6 +123,9 @@ defmodule DiscussWeb.TopicLive.Show do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, comment_form: to_form(changeset))}
+
+      {:error, :unauthorized} ->
+        {:noreply, put_flash(socket, :error, "You must be signed in to comment")}
     end
   end
 

--- a/priv/repo/migrations/20260616221428_make_comments_user_id_non_nullable.exs
+++ b/priv/repo/migrations/20260616221428_make_comments_user_id_non_nullable.exs
@@ -1,0 +1,15 @@
+defmodule Discuss.Repo.Migrations.MakeCommentsUserIdNonNullable do
+  use Ecto.Migration
+
+  def change do
+    # Remove orphaned comments before making user_id non-nullable
+    execute "DELETE FROM comments WHERE user_id IS NULL", ""
+
+    # Drop existing FK constraint before modifying the column
+    drop constraint(:comments, "comments_user_id_fkey")
+
+    alter table(:comments) do
+      modify :user_id, references(:users, on_delete: :delete_all), null: false
+    end
+  end
+end

--- a/test/discuss/discussions_test.exs
+++ b/test/discuss/discussions_test.exs
@@ -7,6 +7,13 @@ defmodule Discuss.DiscussionsTest do
   alias Discuss.Discussions
 
   describe "comments with PubSub" do
+    test "create_comment/3 returns unauthorized for nil user" do
+      topic = topic_fixture()
+
+      assert Discussions.create_comment(nil, topic, %{content: "Hacked"}) ==
+               {:error, :unauthorized}
+    end
+
     test "create_comment/3 broadcasts comment_created event" do
       user = user_fixture()
       topic = topic_fixture()

--- a/test/discuss_web/live/topic_live_test.exs
+++ b/test/discuss_web/live/topic_live_test.exs
@@ -232,5 +232,22 @@ defmodule DiscussWeb.TopicLiveTest do
       assert has_element?(show_live_1, "#comments", "From user 1")
       assert has_element?(show_live_2, "#comments", "From user 1")
     end
+
+    test "unauthenticated user cannot create comment via direct event", %{conn: conn} do
+      topic = topic_fixture()
+
+      # Mount Show page without auth
+      {:ok, show_live, _html} = live(conn, ~p"/topics/#{topic}")
+
+      # Attempt to create a comment by sending the event directly
+      show_live
+      |> render_hook("save_comment", %{"comment" => %{"content" => "Hacked comment"}})
+
+      # The comment should NOT appear in the list
+      refute has_element?(show_live, "#comments", "Hacked comment")
+
+      # Verify the flash message
+      assert render(show_live) =~ "must be signed in"
+    end
   end
 end


### PR DESCRIPTION
## Problem

`create_comment/3` had no nil-user guard — unlike `create_topic/2` which returns `{:error, :unauthorized}` for `nil` user. The `comments.user_id` column was nullable in the DB. An unauthenticated user could craft a LiveView event to create anonymous comments.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Context | `discussions.ex` | Added `def create_comment(nil, _topic, _attrs)` returning `{:error, :unauthorized}` |
| Database | New migration | Made `comments.user_id` non-nullable with `on_delete: :delete_all` |
| Show handler | `show.ex` | Added `{:error, :unauthorized}` match to prevent crash |
| Index handler | `index.ex` | Added `{:error, :unauthorized}` match; tightened `_changeset` pattern |
| Context test | `discussions_test.exs` | Proves create_comment(nil, ...) returns unauthorized |
| Integration test | `topic_live_test.exs` | Proves unauth user sending save_comment event is blocked |

Closes #30