### PR TITLE
test(Index): add unauth comment guard test

### DIFF
--- a/test/discuss_web/live/topic_live_test.exs
+++ b/test/discuss_web/live/topic_live_test.exs
@@ -162,6 +162,22 @@ defmodule DiscussWeb.TopicLiveTest do
       # Verify flash message is shown
       assert render(index_live) =~ "You must be signed in"
     end
+
+    test "unauthenticated user cannot create comment via direct event on Index", %{conn: conn} do
+      topic = topic_fixture()
+
+      {:ok, index_live, _html} = live(conn, ~p"/topics")
+
+      # Attempt to create a comment by sending the event directly
+      index_live
+      |> render_hook("create_comment", %{"topic-id" => to_string(topic.id), "content" => "Hacked comment"})
+
+      # The comment should NOT appear
+      refute has_element?(index_live, "#comments", "Hacked comment")
+
+      # Verify the flash message
+      assert render(index_live) =~ "must be signed in"
+    end
   end
 
   describe "Show" do


### PR DESCRIPTION
Closes #30.

Adds a test for the Index page `create_comment` event to verify unauthenticated users get blocked with a flash message, matching the existing Show page test.