### PR TITLE
fix: format test file for CI

### DIFF
--- a/test/discuss_web/live/topic_live_test.exs
+++ b/test/discuss_web/live/topic_live_test.exs
@@ -170,7 +170,10 @@ defmodule DiscussWeb.TopicLiveTest do
 
       # Attempt to create a comment by sending the event directly
       index_live
-      |> render_hook("create_comment", %{"topic-id" => to_string(topic.id), "content" => "Hacked comment"})
+      |> render_hook("create_comment", %{
+        "topic-id" => to_string(topic.id),
+        "content" => "Hacked comment"
+      })
 
       # The comment should NOT appear
       refute has_element?(index_live, "#comments", "Hacked comment")


### PR DESCRIPTION
Fixes `mix format --check-formatted` failure introduced by PR #50.

The long `render_hook` call was on a single line; the formatter requires the map to be split across multiple lines.