### PR TITLE
fix: make update_topic/2 private, enforce ownership check

### DIFF
--- a/lib/discuss/discussions.ex
+++ b/lib/discuss/discussions.ex
@@ -62,10 +62,7 @@ defmodule Discuss.Discussions do
     |> broadcast_topic(:topic_created)
   end
 
-  @doc """
-  Updates an existing topic and broadcasts to connected users.
-  """
-  def update_topic(%Topic{} = topic, attrs) do
+  defp update_topic(%Topic{} = topic, attrs) do
     topic
     |> Topic.changeset(attrs)
     |> Repo.update()

--- a/test/discuss/discussions_test.exs
+++ b/test/discuss/discussions_test.exs
@@ -75,7 +75,8 @@ defmodule Discuss.DiscussionsTest do
 
       Discussions.subscribe_to_topics()
 
-      {:ok, updated_topic} = Discussions.update_topic(topic, %{title: "Updated Title"})
+      {:ok, updated_topic} =
+        Discussions.update_topic_by_user(topic.user, topic, %{title: "Updated Title"})
 
       assert_receive {:topic_updated, received_topic}
       assert received_topic.id == updated_topic.id

--- a/test/discuss_web/live/topic_live_test.exs
+++ b/test/discuss_web/live/topic_live_test.exs
@@ -89,7 +89,9 @@ defmodule DiscussWeb.TopicLiveTest do
       {:ok, index_live, _html} = live(conn, ~p"/topics")
 
       # Simulate topic being updated by another user via PubSub broadcast
-      {:ok, updated} = Discussions.update_topic(topic, %{title: "Updated from broadcast"})
+      {:ok, updated} =
+        Discussions.update_topic_by_user(topic.user, topic, %{title: "Updated from broadcast"})
+
       updated = Repo.preload(updated, [:user, :comments])
 
       send(index_live.pid, {:topic_updated, updated})


### PR DESCRIPTION
Closes #31.

- Made `update_topic/2` private (`defp`) — removes the unguarded public API
- All 3 LiveView call sites already use `update_topic_by_user/3` ✅
- Updated 2 test call sites to use the guarded version instead

This is the same auth-boundary pattern as the `create_comment` fix in #30:
the ownership check lives at the public API, not downstream.