### PR TITLE
fix: broadcast topic updates to topic-specific channel

### DIFF
--- a/lib/discuss/discussions.ex
+++ b/lib/discuss/discussions.ex
@@ -183,6 +183,7 @@ defmodule Discuss.Discussions do
     topic = Repo.preload(topic, [:user, comments: [:user]])
 
     Phoenix.PubSub.broadcast(Discuss.PubSub, "topics", {event, topic})
+    Phoenix.PubSub.broadcast(Discuss.PubSub, "topic:#{topic.id}", {event, topic})
 
     result
   end

--- a/lib/discuss_web/live/topic_live/show.ex
+++ b/lib/discuss_web/live/topic_live/show.ex
@@ -162,6 +162,14 @@ defmodule DiscussWeb.TopicLive.Show do
      |> stream_delete(:comments, comment)}
   end
 
+  @impl true
+  def handle_info({:topic_updated, topic}, socket) do
+    {:noreply,
+     socket
+     |> assign(:topic, topic)
+     |> assign(:page_title, topic.title)}
+  end
+
   defp assign_comment_form(socket) do
     assign(socket, :comment_form, to_form(Discussions.change_comment(%Comment{})))
   end

--- a/test/discuss_web/live/topic_live_test.exs
+++ b/test/discuss_web/live/topic_live_test.exs
@@ -270,5 +270,18 @@ defmodule DiscussWeb.TopicLiveTest do
       # Verify the flash message
       assert render(show_live) =~ "must be signed in"
     end
+
+    test "receives real-time topic title updates", %{conn: conn} do
+      user = user_fixture()
+      topic = topic_fixture(user)
+      {:ok, show_live, _html} = live(conn, ~p"/topics/#{topic}")
+
+      # Another user updates the topic
+      {:ok, _updated} =
+        Discussions.update_topic_by_user(user, topic, %{title: "Updated from broadcast"})
+
+      # The Show page should see the new title
+      assert has_element?(show_live, "h1", "Updated from broadcast")
+    end
   end
 end


### PR DESCRIPTION
Closes #28.

- `broadcast_topic/2` now also broadcasts to `"topic:#{topic.id}"` channel
- Show LiveView subscribes to this channel (for comments) but never received topic updates
- Added `handle_info({:topic_updated, topic})` handler in Show to update `@topic` and `@page_title`

This means editing a topic title on the Index page now live-updates the Show page in other browsers.