### PR TITLE
fix: add blank line for Elixir 1.18 formatter

### DIFF
--- a/test/discuss/discussions_test.exs
+++ b/test/discuss/discussions_test.exs
@@ -76,6 +76,7 @@ defmodule Discuss.DiscussionsTest do
       Discussions.subscribe_to_topics()
 
       title = "Updated Title"
+
       {:ok, updated_topic} =
         Discussions.update_topic_by_user(topic.user, topic, %{title: title})
 


### PR DESCRIPTION
CI runs Elixir 1.18.2, local runs 1.17.2. The 1.18 formatter requires a blank line between a variable assignment and the next wrapped expression. This was missed in PR #54.