### PR TITLE
chore: bump elixir requirement to ~> 1.18

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Discuss.MixProject do
     [
       app: :discuss,
       version: "0.1.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/test/discuss/discussions_test.exs
+++ b/test/discuss/discussions_test.exs
@@ -76,6 +76,7 @@ defmodule Discuss.DiscussionsTest do
       Discussions.subscribe_to_topics()
 
       title = "Updated Title"
+
       {:ok, updated_topic} =
         Discussions.update_topic_by_user(topic.user, topic, %{title: title})
 


### PR DESCRIPTION
CI runs Elixir 1.18.2, local was 1.17.2. This mismatch caused formatter drift — the 1.18 formatter enforces a blank line rule that 1.17 ignores, breaking CI on every merge.

Changes:
- `mix.exs`: `~> 1.15` → `~> 1.18`
- Local Elixir updated to 1.18.2 via asdf globally

Also makes the `fix/format-ci-182` PR redundant (the blank line fix is included in this upgrade).