### PR TITLE
docs: overhaul README with badges, emojis, cleaner layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,92 @@
-# Discuss
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://socialify.git.ci/mingyar/discuss/image?description=1&font=Inter&forks=1&issues=1&language=1&name=1&owner=1&pattern=Solid&pulls=1&stargazers=1&theme=Dark">
+  <img alt="Discuss" src="https://socialify.git.ci/mingyar/discuss/image?description=1&font=Inter&forks=1&issues=1&language=1&name=1&owner=1&pattern=Solid&pulls=1&stargazers=1&theme=Light">
+</picture>
 
-A real-time discussion board built with Phoenix LiveView. Authenticated users can create topics (threads) and post comments — everything updates live across all connected users via PubSub.
+<div align="center">
 
-## Features
+[![CI](https://github.com/mingyar/discuss/actions/workflows/deploy.yml/badge.svg)](https://github.com/mingyar/discuss/actions/workflows/deploy.yml)
+[![Elixir](https://img.shields.io/badge/Elixir-1.18-4B275F?logo=elixir&logoColor=white)](https://elixir-lang.org)
+[![Phoenix](https://img.shields.io/badge/Phoenix-1.8-FD4F00?logo=phoenix&logoColor=white)](https://phoenixframework.org)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-- **GitHub OAuth** — Sign in with your GitHub account
-- **Topics** — Create, edit, and delete discussion threads
-- **Comments** — Post and delete comments on topics (live updates)
-- **Real-time** — New topics and comments appear instantly via WebSockets
-- **Dark mode** — System/Light/Dark theme toggle with localStorage persistence
-- **Responsive** — Mobile-friendly layout
-- **Health checks** — Liveness and readiness endpoints for zero-downtime deploys
+</div>
 
-## Tech Stack
+**Discuss** is a real-time discussion board built with Phoenix LiveView. Sign in with GitHub, create topics, post comments — everything updates live across all connected users via WebSockets. No page refreshes needed.
 
-| Layer | Technology |
-|-------|-----------|
-| Framework | Phoenix 1.8.3 |
-| LiveView | 1.1.23 |
-| HTTP Server | Bandit |
-| Database | PostgreSQL |
-| Assets | Tailwind CSS 4, esbuild |
-| Auth | Ueberauth + GitHub OAuth |
-| Hosting | Fly.io |
-| CI/CD | GitHub Actions |
+---
 
-## Local Setup
+## ✨ Features
+
+- **🔐 GitHub OAuth** — One-click sign in with your GitHub account
+- **💬 Topics & Comments** — Create, edit, and delete discussion threads
+- **⚡ Real-time** — New topics and comments appear instantly via PubSub
+- **🌙 Dark mode** — System / Light / Dark toggle, persisted across sessions
+- **📱 Responsive** — Works great on desktop and mobile
+- **❤️ Health checks** — Liveness + readiness endpoints for zero-downtime deploys
+
+## 🛠 Tech Stack
+
+| Layer | Choice |
+|-------|--------|
+| **Framework** | Phoenix 1.8 + LiveView 1.1 |
+| **Database** | PostgreSQL |
+| **Styling** | Tailwind CSS 4 + daisyUI |
+| **Auth** | Ueberauth + GitHub OAuth |
+| **Hosting** | Fly.io |
+| **CI/CD** | GitHub Actions |
+
+## 🚀 Quick Start
 
 ### Prerequisites
 
-- Elixir ~> 1.15, OTP 26+
+- Elixir ~> 1.18, OTP 27+
 - PostgreSQL running locally
-- A [GitHub OAuth App](https://github.com/settings/developers) (for dev)
+- A [GitHub OAuth App](https://github.com/settings/developers) (for local dev)
 
-### Quick Start
+### Setup
 
 ```bash
-# 1. Set GitHub OAuth credentials
+# 1. Set your GitHub OAuth credentials
 export GITHUB_CLIENT_ID=your_dev_client_id
 export GITHUB_CLIENT_SECRET=your_dev_client_secret
 
-# 2. Install deps and create database
+# 2. Install dependencies, create database, build assets
 mix setup
 
 # 3. Start the server
 mix phx.server
 
-# 4. Open http://localhost:4000
+# 4. Open http://localhost:4000 🎉
 ```
 
-> A `.env` file with dev credentials is included. Run `source .env` to load it.
+> A `.env` file with dev credentials is included — run `source .env` to load it.
 
 ### GitHub OAuth (Dev)
 
-Create an OAuth App at GitHub → Settings → Developer Settings with:
+Create an OAuth App at [GitHub Developer Settings](https://github.com/settings/developers) with:
 
-- **Homepage URL:** `http://localhost:4000`
-- **Callback URL:** `http://localhost:4000/auth/github/callback`
+| Field | Value |
+|-------|-------|
+| **Homepage URL** | `http://localhost:4000` |
+| **Callback URL** | `http://localhost:4000/auth/github/callback` |
 
 ### Useful Commands
 
-| Command | Description |
-|---------|-------------|
+| Command | What it does |
+|---------|--------------|
 | `mix setup` | Full project setup (deps, DB, assets) |
-| `mix test` | Run tests |
-| `mix phx.server` | Start dev server |
-| `mix precommit` | Compile, format, test — all checks |
-| `iex -S mix phx.server` | Start server with IEx shell |
+| `mix test` | Run the test suite |
+| `mix phx.server` | Start the dev server |
+| `mix precommit` | Format → Compile → Test (all checks) |
+| `iex -S mix phx.server` | Dev server with an IEx shell |
 
-## Deployment
+## 📦 Deployment
 
-### Production on Fly.io
+### Fly.io
 
 ```bash
-# Set secrets
+# Set production secrets
 flyctl secrets set SECRET_KEY_BASE=$(mix phx.gen.secret)
 flyctl secrets set DATABASE_URL="postgresql://..."
 flyctl secrets set GITHUB_CLIENT_ID="..."
@@ -85,39 +98,42 @@ flyctl deploy
 
 ### CI/CD
 
-Every push to `main` triggers GitHub Actions:
+Every push to `master` triggers GitHub Actions:
 
-1. **Test** — Compile, format check, run test suite
-2. **Deploy** — Build Docker image, run migrations (rolling deploy)
+1. **Test** — Compile, format check, test suite
+2. **Deploy** — Build Docker image, run migrations, rolling deploy
 
-Requires `FLY_API_TOKEN` secret in GitHub repository settings.
+> Requires `FLY_API_TOKEN` secret in the repository settings.
 
-## Architecture
+## 🧱 Architecture
 
 ```
-Discuss
-├── Accounts        — User management, GitHub OAuth
-├── Discussions     — Topics and comments, PubSub broadcasts
-├── DiscussWeb
-│   ├── TopicLive   — LiveView: Index (topic list + composer), Show (topic + comments)
-│   ├── Auth        — AuthController, SetUser/RequireAuth plugs
-│   ├── Health      — Liveness and readiness endpoints
-│   └── Components  — Layouts, FormComponent, UI components
-└── Release         — DB migration helper for Fly.io release command
+discuss/
+├── discuss/
+│   ├── accounts/        # User management, GitHub OAuth
+│   └── discussions/     # Topics, comments, PubSub broadcasts
+├── discuss_web/
+│   ├── live/
+│   │   ├── topic_live/  # Index (list + composer), Show (detail + comments)
+│   │   └── ...          # Other LiveViews
+│   ├── controllers/     # AuthController, HealthController
+│   └── components/      # Layouts, shared UI components
+└── releases/            # Migration helper for Fly.io release command
 ```
 
-## API Routes
+## 🗺 Routes
 
-| Path | Description |
-|------|-------------|
+| Path | What it does |
+|------|--------------|
 | `/` | Home |
 | `/topics` | Topic listing |
 | `/topics/:id` | Topic detail + comments |
-| `/health/*` | Health checks |
-| `/auth/github` | GitHub sign in |
+| `/health/liveness` | Liveness probe |
+| `/health/readiness` | Readiness probe |
+| `/auth/github` | Sign in with GitHub |
 | `/auth/github/callback` | OAuth callback |
 | `/dev/dashboard` | LiveDashboard (dev only) |
 
-## License
+## 📄 License
 
-MIT
+This project is licensed under the MIT License.


### PR DESCRIPTION
Major README refresh:

- Auto-generated social banner (dark/light aware)
- CI + version badges at the top
- Emoji section headers for visual scannability
- Cleaner tables and formatting throughout
- Removed Bandit from tech stack (default, not a choice)
- OTP version bumped to match project requirements