### PR TITLE
Fix #35: find_or_create_user/1 handles string keys

### DIFF
--- a/lib/discuss/accounts.ex
+++ b/lib/discuss/accounts.ex
@@ -37,6 +37,18 @@ defmodule Discuss.Accounts do
     end
   end
 
+  def find_or_create_user(attrs)
+      when is_map(attrs) and is_map_key(attrs, "provider") and is_map_key(attrs, "uid") do
+    # String keys from e.g. Ueberauth — normalize to atom keys and delegate
+    normalized =
+      Map.new(attrs, fn
+        {key, val} when is_binary(key) -> {String.to_existing_atom(key), val}
+        {key, val} -> {key, val}
+      end)
+
+    find_or_create_user(normalized)
+  end
+
   @doc """
   Creates a new user.
   """

--- a/test/discuss/accounts_test.exs
+++ b/test/discuss/accounts_test.exs
@@ -71,6 +71,19 @@ defmodule Discuss.AccountsTest do
       assert user.email == existing.email
     end
 
+    test "handles string keys by normalizing them" do
+      attrs = %{
+        "provider" => "github",
+        "uid" => "string_key_uid",
+        "email" => "string@example.com",
+        "name" => "String Key"
+      }
+
+      assert {:ok, %User{} = user} = Accounts.find_or_create_user(attrs)
+      assert user.uid == "string_key_uid"
+      assert user.provider == "github"
+    end
+
     test "raises FunctionClauseError when provider key is missing" do
       assert_raise FunctionClauseError, fn ->
         Accounts.find_or_create_user(%{uid: "no_provider"})


### PR DESCRIPTION
Adds a second function clause that normalizes string-key maps (from e.g. Ueberauth) to atom keys before delegating to the existing atom-key clause.

### Test-first approach
1. Wrote a test proving string keys should work — it failed with `FunctionClauseError`
2. Implemented the fix — test now passes
3. All 64 tests green

Closes #35