### PR TITLE
Fix #43: signout works without JavaScript

### DIFF
--- a/lib/discuss_web/components/layouts/app.html.heex
+++ b/lib/discuss_web/components/layouts/app.html.heex
@@ -33,13 +33,15 @@
                 <span>{@current_user.name || @current_user.email}</span>
               </li>
               <li>
-                <.link
-                  href="/auth/signout"
-                  method="delete"
-                  class="text-error hover:text-error/80"
-                >
-                  Sign Out
-                </.link>
+                <form action="/auth/signout" method="post" class="block">
+                  <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
+                  <button
+                    type="submit"
+                    class="w-full text-left text-error hover:text-error/80 cursor-pointer px-4 py-2"
+                  >
+                    Sign Out
+                  </button>
+                </form>
               </li>
             </ul>
           </details>

--- a/lib/discuss_web/router.ex
+++ b/lib/discuss_web/router.ex
@@ -36,7 +36,7 @@ defmodule DiscussWeb.Router do
 
     get "/:provider", AuthController, :request
     get "/:provider/callback", AuthController, :callback
-    delete "/signout", AuthController, :signout
+    post "/signout", AuthController, :signout
   end
 
   # Other scopes may use custom stacks.

--- a/test/discuss_web/controllers/auth_controller_test.exs
+++ b/test/discuss_web/controllers/auth_controller_test.exs
@@ -73,12 +73,12 @@ defmodule DiscussWeb.AuthControllerTest do
     end
   end
 
-  describe "DELETE /auth/signout" do
-    test "signs out and clears session", %{conn: conn} do
+  describe "POST /auth/signout" do
+    test "signs out without JavaScript", %{conn: conn} do
       user = user_fixture()
       conn = conn |> Plug.Test.init_test_session(%{user_id: user.id})
 
-      conn = delete(conn, ~p"/auth/signout")
+      conn = post(conn, ~p"/auth/signout")
 
       assert redirected_to(conn) == ~p"/"
       assert flash(conn, :info) =~ "Signed out"


### PR DESCRIPTION
Replaces the JS-only `<.link method="delete">` with an HTML `<form method="post">` + CSRF token.

### Changes
- **app.html.heex**: Link → form with submit button
- **router.ex**: `delete "/signout"` → `post "/signout"`
- **auth_controller_test.exs**: Test updated from DELETE to POST

### Test-first approach
1. Wrote test proving POST /auth/signout should work — it failed with 404
2. Implemented the fix — test now passes
3. All 64 tests green

Closes #43
