### PR TITLE
fix: fail fast on missing GITHUB_CLIENT_ID in production

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -27,13 +27,13 @@ end
 config :discuss, DiscussWeb.Endpoint,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
-# GitHub OAuth credentials — must be at runtime (env vars from Fly.io
-# are not available at compile time during release builds).
-config :ueberauth, Ueberauth.Strategy.Github.OAuth,
-  client_id: System.get_env("GITHUB_CLIENT_ID"),
-  client_secret: System.get_env("GITHUB_CLIENT_SECRET")
-
 if config_env() == :prod do
+  # GitHub OAuth credentials — must be at runtime (env vars from Fly.io
+  # are not available at compile time during release builds).
+  config :ueberauth, Ueberauth.Strategy.Github.OAuth,
+    client_id: System.fetch_env!("GITHUB_CLIENT_ID"),
+    client_secret: System.fetch_env!("GITHUB_CLIENT_SECRET")
+
   database_url =
     System.get_env("DATABASE_URL") ||
       raise """


### PR DESCRIPTION
Closes #45.

Moves GitHub OAuth config inside `if config_env() == :prod` block
and switches from `System.get_env/1` to `System.fetch_env!/1`.

Now a production deploy without `GITHUB_CLIENT_ID` or
`GITHUB_CLIENT_SECRET` crashes immediately at startup with a clear
error, instead of passing `nil` silently and failing later with an
obscure GitHub OAuth error on the first login attempt.

Aligns with the existing pattern used by `SECRET_KEY_BASE` (line 119).