### PR TITLE
fix: remove dead /topics/new route

### DIFF
--- a/lib/discuss_web/live/topic_live/index.ex
+++ b/lib/discuss_web/live/topic_live/index.ex
@@ -38,14 +38,6 @@ defmodule DiscussWeb.TopicLive.Index do
     |> assign(:topic, nil)
   end
 
-  defp apply_action(socket, :new, _params) do
-    # Inline composer replaces the new-topic modal, redirect to index
-    socket
-    |> assign(:page_title, "Topics")
-    |> assign(:topic, nil)
-    |> push_navigate(to: ~p"/topics")
-  end
-
   @impl true
   def handle_info({:topic_created, topic}, socket) do
     {:noreply, stream_insert(socket, :topics, topic, at: 0)}

--- a/lib/discuss_web/router.ex
+++ b/lib/discuss_web/router.ex
@@ -21,7 +21,6 @@ defmodule DiscussWeb.Router do
 
       live "/", TopicLive.Index, :index
       live "/topics", TopicLive.Index, :index
-      live "/topics/new", TopicLive.Index, :new
       live "/topics/:id", TopicLive.Show, :show
     end
   end


### PR DESCRIPTION
Closes #39.

The inline composer replaced the separate new-topic flow. The
`/topics/new` route only existed to immediately redirect back to
`/topics` via `push_navigate`. Removed:

- `live \/topics/new\, TopicLive.Index, :new` from `router.ex`
- `apply_action(socket, :new, ...)` from `index.ex`